### PR TITLE
Aggiungi supporto per file ZIP con decompressione automatica

### DIFF
--- a/Greppy.xcodeproj/project.pbxproj
+++ b/Greppy.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		87AA61BE2B7903910084639A /* GreppyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GreppyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		87AA61C02B7903910084639A /* GreppyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreppyUITests.swift; sourceTree = "<group>"; };
 		87AA61C22B7903910084639A /* GreppyUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreppyUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		87ZIPARCH2B7903910084639B /* Greppy-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Greppy-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +83,7 @@
 			children = (
 				874F87DA2B88E422008EA384 /* SaveDocumentPicker.swift */,
 				87AA61B92B78F1730084639A /* Info.plist */,
+				87ZIPARCH2B7903910084639B /* Greppy-Bridging-Header.h */,
 				874386552B78B7F100C10504 /* GreppyApp.swift */,
 				874386572B78B7F100C10504 /* ContentView.swift */,
 				8736307F2B84E39E00436D44 /* settingLinesBeforeAfter.swift */,
@@ -381,6 +383,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.cagnulein.Greppy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Greppy/Greppy-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -413,6 +416,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.cagnulein.Greppy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Greppy/Greppy-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Greppy/Greppy-Bridging-Header.h
+++ b/Greppy/Greppy-Bridging-Header.h
@@ -1,0 +1,11 @@
+//
+//  Greppy-Bridging-Header.h
+//  Greppy
+//
+
+#ifndef Greppy_Bridging_Header_h
+#define Greppy_Bridging_Header_h
+
+#import <zlib.h>
+
+#endif /* Greppy_Bridging_Header_h */

--- a/Greppy/Info.plist
+++ b/Greppy/Info.plist
@@ -24,6 +24,17 @@
 				<string>public.zip-archive</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Files without extension</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+		</dict>
 	</array>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<false/>

--- a/Greppy/Info.plist
+++ b/Greppy/Info.plist
@@ -14,6 +14,16 @@
 				<string>public.plain-text</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>ZIP Archives</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.zip-archive</string>
+			</array>
+		</dict>
 	</array>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<false/>


### PR DESCRIPTION
- Aggiornato Info.plist per accettare file ZIP (public.zip-archive)
- Modificato DocumentPicker per permettere selezione di file ZIP
- Implementato parser ZIP personalizzato con supporto DEFLATE
- Aggiunto bridging header per usare libreria zlib
- I file ZIP vengono automaticamente decompressi e i file di testo contenuti vengono caricati nell'app
- I file estratti sono mostrati con formato "archive.zip/filename.txt"